### PR TITLE
Move webpack-dev-server to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "style-loader": "^0.18.2",
-    "webpack": "^3.5.5",
-    "webpack-dev-server": "^2.7.1"
+    "webpack": "^3.5.5"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -50,6 +49,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "babel-register": "^6.26.0",
-    "less": "^2.7.2"
+    "less": "^2.7.2",
+    "webpack-dev-server": "^2.7.1"
   }
 }


### PR DESCRIPTION
webpack-dev-server package is clearly a part of development dependencies. You might want to change this part in your blogpost on codeburst as well: https://codeburst.io/setting-up-a-react-project-from-scratch-d62f38ab6d97

`npm i --save webpack`
`npm i --save-dev webpack-dev-server`

 instead of `npm install --save webpack webpack-dev-server`